### PR TITLE
Update fortios.rb

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -77,6 +77,8 @@ class FortiOS < Oxidized::Model
       fullcfg = cmd(fullcmd)
       next if fullcfg.lines[1..3].join =~ /(Parsing error at|command parse error)/ # Don't show for unsupported devices (e.g. FortiAnalyzer, FortiManager, FortiMail)
 
+      fullcfg.gsub! /(set comments "Error \(No order found for account ID \d+\) on).*/, '\\1 <stripped>'
+
       cfg << fullcfg
       break
     end


### PR DESCRIPTION
filter date in comment when using acme

```
config vpn certificate local
..
    edit "fgvm-fw.customer.domain"
        set password <configuration removed>
-       set comments "Error (No order found for account ID 1713433947) on Tue May 14 06:17:32 2024 (UTC)"
+       set comments "Error (No order found for account ID 1713433947) on <stripped>
        set range global
        set enroll-protocol acme2
        set acme-domain "fgvm-fw.customer.domain"
        set acme-email "nospam@domain.tld"
    next
end
```

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
